### PR TITLE
Remove broken Codespaces badges from workshop READMEs

### DIFF
--- a/workshops/agent_memory_workshop/README.md
+++ b/workshops/agent_memory_workshop/README.md
@@ -2,8 +2,6 @@
 
 **Build memory-aware AI agents with Oracle AI Database, LangChain, and Tavily**
 
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/speechlyze/agent_memory_workshop)
-
 ---
 
 ## What You Will Build

--- a/workshops/agent_memory_workshop/README.md
+++ b/workshops/agent_memory_workshop/README.md
@@ -23,66 +23,6 @@ A **Research Paper Assistant** — an AI agent that searches, retrieves, and rea
 
 ## Getting Started
 
-### Option A: GitHub Codespaces (recommended for the workshop)
-
-1. Click the **Open in GitHub Codespaces** badge above
-2. Click the **Create Codespace** button to launch your environment
-
-   ![Create Codespace](images/codespaces_creation.png)
-
-3. Wait for the environment to build (~3-5 minutes)
-
-   ![Codespace startup](images/codespace_startup.png)
-
-4. Once the terminal prompt appears, start Oracle AI Database:
-
-   > **Tip:** If your browser prompts you to allow clipboard pasting, click **Allow** so you can paste commands into the terminal.
-
-   ```bash
-   docker compose -f .devcontainer/docker-compose.yml up -d oracle
-   ```
-
-   ![Oracle getting pulled](images/oracle_getting_pulled.png)
-
-5. Wait for Oracle to become healthy (~60-90 seconds), then verify:
-
-   ```bash
-   docker ps
-   ```
-
-   You should see `(healthy)` in the STATUS column for the `oracle-free` container.
-
-   ![Oracle ready](images/oracle_ready.png)
-
-6. Confirm the Python connection works:
-
-   ```bash
-   python3 -c "import oracledb; c = oracledb.connect(user='VECTOR', password='VectorPwd_2025', dsn='localhost:1521/FREEPDB1'); print('Connected. Oracle version:', c.version); c.close()"
-   ```
-
-   ![Database ready](images/database_ready.png)
-
-7. Open [`workshop/notebook_student.ipynb`](workshop/notebook_student.ipynb) in the file explorer
-8. Select the **Python 3.11** kernel:
-
-   Click **Select Kernel** in the top-right corner of the notebook:
-
-   ![Select Kernel](images/select_kernel.png)
-
-   Choose **Python 3.11** from the list:
-
-   ![Select Python 3.11](images/select_kernel_python_3.11.png)
-
-   Confirm it shows as selected:
-
-   ![Kernel Selected](images/ensure_kernel_selected.png)
-
-9. Follow the notebook cells top to bottom, using the part guides in `docs/` when you hit a TODO
-
-> **Note:** On subsequent Codespace opens, Oracle should start automatically via `postStartCommand`. If you ever see a connection error in the notebook, run step 3 above again from the terminal.
-
-### Option B: Local development
-
 This workshop lives inside the [oracle-ai-developer-hub](https://github.com/oracle-devrel/oracle-ai-developer-hub) repository. Use **git sparse-checkout** to pull just this workshop without cloning the rest of the hub:
 
 ```bash

--- a/workshops/from_rag_to_agents_workshop/README.md
+++ b/workshops/from_rag_to_agents_workshop/README.md
@@ -2,8 +2,6 @@
 
 **Build a complete RAG pipeline and agentic system with Oracle AI Database, OpenAI, and the Agents SDK**
 
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/speechlyze/from_rag_to_agents_workshop)
-
 ---
 
 ## What You Will Build

--- a/workshops/from_rag_to_agents_workshop/README.md
+++ b/workshops/from_rag_to_agents_workshop/README.md
@@ -25,66 +25,6 @@ Starting from raw data, you will construct a **Research Paper Assistant** — a 
 
 ## Getting Started
 
-### Option A: GitHub Codespaces (recommended for the workshop)
-
-1. Click the **Open in GitHub Codespaces** badge above
-2. Click the **Create Codespace** button to launch your environment
-
-   ![Create Codespace](images/codespaces_creation.png)
-
-3. Wait for the environment to build (~3-5 minutes)
-
-   ![Codespace startup](images/codespace_startup.png)
-
-4. Once the terminal prompt appears, start Oracle AI Database:
-
-   > **Tip:** If your browser prompts you to allow clipboard pasting, click **Allow** so you can paste commands into the terminal.
-
-   ```bash
-   docker compose -f .devcontainer/docker-compose.yml up -d oracle
-   ```
-
-   ![Oracle getting pulled](images/oracle_getting_pulled.png)
-
-5. Wait for Oracle to become healthy (~60-90 seconds), then verify:
-
-   ```bash
-   docker ps
-   ```
-
-   You should see `(healthy)` in the STATUS column for the `oracle-free` container.
-
-   ![Oracle ready](images/oracle_ready.png)
-
-6. Confirm the Python connection works:
-
-   ```bash
-   python3 -c "import oracledb; c = oracledb.connect(user='VECTOR', password='VectorPwd_2025', dsn='localhost:1521/FREEPDB1'); print('Connected. Oracle version:', c.version); c.close()"
-   ```
-
-   ![Database ready](images/database_ready.png)
-
-7. Open [`workshop/notebook_student.ipynb`](workshop/notebook_student.ipynb) in the file explorer
-8. Select the **Python 3.11** kernel:
-
-   Click **Select Kernel** in the top-right corner of the notebook:
-
-   ![Select Kernel](images/select_kernel.png)
-
-   Choose **Python 3.11** from the list:
-
-   ![Select Python 3.11](images/select_kernel_python_3.11.png)
-
-   Confirm it shows as selected:
-
-   ![Kernel Selected](images/ensure_kernel_selected.png)
-
-9. Follow the notebook cells top to bottom, using the part guides in `docs/` when you hit a TODO
-
-> **Note:** On subsequent Codespace opens, Oracle should start automatically via `postStartCommand`. If you ever see a connection error in the notebook, run step 3 above again from the terminal.
-
-### Option B: Local development
-
 This workshop lives inside the [oracle-ai-developer-hub](https://github.com/oracle-devrel/oracle-ai-developer-hub) repository. Use **git sparse-checkout** to pull just this workshop without cloning the rest of the hub:
 
 ```bash

--- a/workshops/information_retrieval_to_RAG/README.md
+++ b/workshops/information_retrieval_to_RAG/README.md
@@ -2,8 +2,6 @@
 
 **Build a complete information retrieval and RAG pipeline with Oracle AI Database and OCI GenAI (xAI Grok 3 Fast)**
 
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/speechlyze/information_retrieval_to_RAG)
-
 ---
 
 ## What You Will Build

--- a/workshops/information_retrieval_to_RAG/README.md
+++ b/workshops/information_retrieval_to_RAG/README.md
@@ -87,7 +87,7 @@ information_retrieval_to_RAG/
 
 ## Where to Next?
 
-- **[From RAG to Agents Workshop](https://github.com/speechlyze/from_rag_to_agents_workshop)** — Continue the journey by adding AI agents, multi-agent orchestration, and persistent session memory on top of this RAG pipeline
+- **[From RAG to Agents Workshop](https://github.com/oracle-devrel/oracle-ai-developer-hub/tree/main/workshops/from_rag_to_agents_workshop)** — Continue the journey by adding AI agents, multi-agent orchestration, and persistent session memory on top of this RAG pipeline
 - **[Oracle AI Developer Hub](https://github.com/oracle-devrel/oracle-ai-developer-hub)** — More technical assets, samples, and projects with Oracle AI
 - **[Oracle Developer Resource](https://www.oracle.com/developer/)** — Documentation, tools, and community for Oracle developers
 

--- a/workshops/information_retrieval_to_RAG/README.md
+++ b/workshops/information_retrieval_to_RAG/README.md
@@ -22,66 +22,6 @@ Starting from raw data, you will construct a **Research Paper Assistant** — a 
 
 ## Getting Started
 
-### Option A: GitHub Codespaces (recommended for the workshop)
-
-1. Click the **Open in GitHub Codespaces** badge above
-2. Click the **Create Codespace** button to launch your environment
-
-   ![Create Codespace](images/codespaces_creation.png)
-
-3. Wait for the environment to build (~3-5 minutes)
-
-   ![Codespace startup](images/codespace_startup.png)
-
-4. Once the terminal prompt appears, start Oracle AI Database:
-
-   > **Tip:** If your browser prompts you to allow clipboard pasting, click **Allow** so you can paste commands into the terminal.
-
-   ```bash
-   docker compose -f .devcontainer/docker-compose.yml up -d oracle
-   ```
-
-   ![Oracle getting pulled](images/oracle_getting_pulled.png)
-
-5. Wait for Oracle to become healthy (~60-90 seconds), then verify:
-
-   ```bash
-   docker ps
-   ```
-
-   You should see `(healthy)` in the STATUS column for the `oracle-free` container.
-
-   ![Oracle ready](images/oracle_ready.png)
-
-6. Confirm the Python connection works:
-
-   ```bash
-   python3 -c "import oracledb; c = oracledb.connect(user='VECTOR', password='VectorPwd_2025', dsn='localhost:1521/FREEPDB1'); print('Connected. Oracle version:', c.version); c.close()"
-   ```
-
-   ![Database ready](images/database_ready.png)
-
-7. Open [`workshop/notebook_student.ipynb`](workshop/notebook_student.ipynb) in the file explorer
-8. Select the **Python 3.11** kernel:
-
-   Click **Select Kernel** in the top-right corner of the notebook:
-
-   ![Select Kernel](images/select_kernel.png)
-
-   Choose **Python 3.11** from the list:
-
-   ![Select Python 3.11](images/select_kernel_python_3.11.png)
-
-   Confirm it shows as selected:
-
-   ![Kernel Selected](images/ensure_kernel_selected.png)
-
-9. Follow the notebook cells top to bottom, using the part guides in `docs/` when you hit a TODO
-
-> **Note:** On subsequent Codespace opens, Oracle should start automatically via `postStartCommand`. If you ever see a connection error in the notebook, run step 4 above again from the terminal.
-
-### Option B: Local development
-
 This workshop lives inside the [oracle-ai-developer-hub](https://github.com/oracle-devrel/oracle-ai-developer-hub) repository. Use **git sparse-checkout** to pull just this workshop without cloning the rest of the hub:
 
 ```bash

--- a/workshops/information_retrieval_to_RAG/workshop/notebook_complete.ipynb
+++ b/workshops/information_retrieval_to_RAG/workshop/notebook_complete.ipynb
@@ -1709,7 +1709,7 @@
     "\n",
     "You've built a complete information retrieval and RAG pipeline. Here are some paths to continue:\n",
     "\n",
-    "- **[From RAG to Agents Workshop](https://github.com/speechlyze/from_rag_to_agents_workshop)** \u2014 Continue the journey by adding AI agents, multi-agent orchestration, and persistent session memory on top of this RAG pipeline\n",
+    "- **[From RAG to Agents Workshop](https://github.com/oracle-devrel/oracle-ai-developer-hub/tree/main/workshops/from_rag_to_agents_workshop)** \u2014 Continue the journey by adding AI agents, multi-agent orchestration, and persistent session memory on top of this RAG pipeline\n",
     "- **[Oracle AI Developer Hub](https://github.com/oracle-devrel/oracle-ai-developer-hub)** \u2014 More technical assets, samples, and projects with Oracle AI\n",
     "- **[Oracle Developer Resource](https://www.oracle.com/developer/)** \u2014 Documentation, tools, and community for Oracle developers"
    ]

--- a/workshops/information_retrieval_to_RAG/workshop/notebook_student.ipynb
+++ b/workshops/information_retrieval_to_RAG/workshop/notebook_student.ipynb
@@ -1579,7 +1579,7 @@
     "\n",
     "You've built a complete information retrieval and RAG pipeline. Here are some paths to continue:\n",
     "\n",
-    "- **[From RAG to Agents Workshop](https://github.com/speechlyze/from_rag_to_agents_workshop)** \u2014 Continue the journey by adding AI agents, multi-agent orchestration, and persistent session memory on top of this RAG pipeline\n",
+    "- **[From RAG to Agents Workshop](https://github.com/oracle-devrel/oracle-ai-developer-hub/tree/main/workshops/from_rag_to_agents_workshop)** \u2014 Continue the journey by adding AI agents, multi-agent orchestration, and persistent session memory on top of this RAG pipeline\n",
     "- **[Oracle AI Developer Hub](https://github.com/oracle-devrel/oracle-ai-developer-hub)** \u2014 More technical assets, samples, and projects with Oracle AI\n",
     "- **[Oracle Developer Resource](https://www.oracle.com/developer/)** \u2014 Documentation, tools, and community for Oracle developers"
    ]


### PR DESCRIPTION
## Summary
- Removed the **Open in GitHub Codespaces** badge from each of the three workshop READMEs (`agent_memory_workshop`, `from_rag_to_agents_workshop`, `information_retrieval_to_RAG`). The badges all linked to `codespaces.new/speechlyze/...`, which is not the canonical location for these workshops.
- Dropped the **Option A: GitHub Codespaces** instructions section from each README (which referenced the now-removed badge) and promoted the local-development path to be the body of **Getting Started**.
- Repointed the "From RAG to Agents Workshop" link in `workshops/information_retrieval_to_RAG`'s README and both notebooks (`notebook_student.ipynb`, `notebook_complete.ipynb`) from `github.com/speechlyze/from_rag_to_agents_workshop` to the sibling workshop path inside this hub.

The workshops can be re-introduced to Codespaces in a follow-up PR once a correct entry point under `oracle-devrel/oracle-ai-developer-hub` is set up.

## Test plan
- [ ] Render each updated README on GitHub and confirm the badge no longer appears in the header.
- [ ] Confirm "Getting Started" reads cleanly with only the local-dev (sparse-checkout) instructions.
- [ ] Confirm the "Workshop Files" tree still accurately describes the `.devcontainer/` files (they remain on disk for future Codespaces use).
- [ ] Click the "From RAG to Agents Workshop" link in the information_retrieval_to_RAG README and notebooks and confirm it lands on the sibling workshop directory in this hub.