### PR TITLE
Scaffold partners/langchain directory at repo root

### DIFF
--- a/partners/langchain/README.md
+++ b/partners/langchain/README.md
@@ -1,0 +1,9 @@
+# Partners · LangChain
+
+This directory hosts LangChain-related partner content for the Oracle AI
+Developer Hub — notebooks, examples, and integration scaffolding that show how
+LangChain (and LangGraph) projects use Oracle AI Database primitives such as
+`OracleVS`, `OracleSemanticCache`, `OracleChatMessageHistory`,
+`AsyncOracleStore`, and `AsyncOracleSaver`.
+
+Contents will be filled in as partner integrations land.


### PR DESCRIPTION
Adds an empty `partners/langchain/` folder with a placeholder README so future LangChain / LangGraph partner integrations (notebooks, examples, scaffolding for OracleVS, OracleSemanticCache, OracleChatMessageHistory, AsyncOracleStore, AsyncOracleSaver) have a stable home in the hub.